### PR TITLE
Fix Vercel build by skipping Cloudflare dev proxy in production

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,7 +43,7 @@ export default defineConfig((config) => {
           return null;
         },
       },
-      config.mode !== 'test' && remixCloudflareDevProxy(),
+      config.command === 'serve' && config.mode !== 'test' && remixCloudflareDevProxy(),
       remixVitePlugin({
         future: {
           v3_fetcherPersist: true,


### PR DESCRIPTION
## Summary
- guard the Cloudflare development proxy plugin so it only runs for the Vite dev server

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e27efb3c98832b901a4c95e8880b82